### PR TITLE
Enable GitHub Pages deployment from public

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -2,11 +2,8 @@
 name: Deploy static content to Pages
 
 on:
-  # Runs on pushes targeting the default branch
   push:
-    branches: ["v4"]
-
-  # Allows you to run this workflow manually from the Actions tab
+    branches: ["main"]
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
@@ -36,8 +33,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire repository
-          path: '/public'
+          path: ./public
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -7,3 +7,16 @@
 
 Kolscha war auch hier :>
 
+## GitHub Pages Deployment
+
+Dieses Repository enthält einen GitHub Actions Workflow, der den Inhalt des Ordners `public` auf GitHub Pages veröffentlicht.
+
+### Anleitung
+
+1. Push das Repo zu GitHub.
+2. Öffne in GitHub **Settings → Pages** und wähle **GitHub Actions** als Quelle.
+3. Bei jedem Push auf den `main`‑Branch läuft `.github/workflows/static.yml` und deployed den `public` Ordner.
+4. Die Website ist danach unter `https://<username>.github.io/<repository>/` erreichbar.
+
+Wenn dein Hauptbranch anders heißt, passe den Branchnamen in `.github/workflows/static.yml` an.
+


### PR DESCRIPTION
## Summary
- Configure GitHub Actions workflow to deploy the `public` directory to GitHub Pages
- Document how to enable GitHub Pages deployment

## Testing
- `npm test`
- `npm run check` *(fails: Type 'Item' does not satisfy the constraint 'DocumentData')*

------
https://chatgpt.com/codex/tasks/task_e_68b705fd17a483338aa0775ab71abf2d